### PR TITLE
cicd: Reorganize values

### DIFF
--- a/cicd/deploy/dev.yaml
+++ b/cicd/deploy/dev.yaml
@@ -2,25 +2,3 @@ protocol-union-api:
   service:
     nodePort: 30318
 
-protocol-union-meta-loader:
-  replicas: 1
-  resources:
-    jvm:
-      xmx_megabytes: 512
-      max_direct_memory_megabytes: 128
-
-protocol-union-indexer:
-  enabled: true
-  replicas: 1
-  resources:
-    jvm:
-      xmx_megabytes: 256
-      max_direct_memory_megabytes: 128
-
-protocol-union-worker:
-  enabled: true
-  replicas: 1
-  resources:
-    jvm:
-      xmx_megabytes: 256
-      max_direct_memory_megabytes: 128

--- a/cicd/deploy/infura-test.yaml
+++ b/cicd/deploy/infura-test.yaml
@@ -55,12 +55,14 @@ protocol-union-meta-loader:
     <<: *sharedEnvironments
 
 protocol-union-indexer:
+  enabled: false
   tolerations:
     - *sharedTolerations
   environments:
     <<: *sharedEnvironments
 
 protocol-union-worker:
+  enabled: false
   tolerations:
     - *sharedTolerations
   environments:

--- a/cicd/deploy/infura.yaml
+++ b/cicd/deploy/infura.yaml
@@ -55,12 +55,14 @@ protocol-union-meta-loader:
       max_direct_memory_megabytes: 512
 
 protocol-union-indexer:
+  enabled: false
   tolerations:
     - *sharedTolerations
   environments:
     <<: *sharedEnvironments
 
 protocol-union-worker:
+  enabled: false
   tolerations:
     - *sharedTolerations
   environments:

--- a/cicd/deploy/prod.yaml
+++ b/cicd/deploy/prod.yaml
@@ -17,10 +17,9 @@ protocol-union-meta-loader:
   replicas: 6
   resources:
     jvm:
-      xmx_megabytes: 2048
+      xmx_megabytes: 1536
 
 protocol-union-indexer:
-  enabled: true
   replicas: 3
   resources:
     jvm:
@@ -28,8 +27,6 @@ protocol-union-indexer:
       max_direct_memory_megabytes: 256
 
 protocol-union-worker:
-  enabled: true
-  replicas: 1
   resources:
     jvm:
       xmx_megabytes: 512

--- a/cicd/deploy/staging.yaml
+++ b/cicd/deploy/staging.yaml
@@ -1,32 +1,4 @@
 protocol-union-api:
   service:
     nodePort: 30218
-  resources:
-    jvm:
-      xmx_megabytes: 512
-      max_direct_memory_megabytes: 32
 
-protocol-union-listener:
-  resources:
-    jvm:
-      xmx_megabytes: 2048
-      max_direct_memory_megabytes: 196
-
-protocol-union-meta-loader:
-  replicas: 3
-
-protocol-union-indexer:
-  enabled: true
-  replicas: 2
-  resources:
-    jvm:
-      xmx_megabytes: 1024
-      max_direct_memory_megabytes: 512
-
-protocol-union-worker:
-  enabled: true
-  replicas: 1
-  resources:
-    jvm:
-      xmx_megabytes: 256
-      max_direct_memory_megabytes: 128

--- a/cicd/deploy/testnet.yaml
+++ b/cicd/deploy/testnet.yaml
@@ -10,17 +10,4 @@ protocol-union-meta-loader:
   replicas: 3
 
 protocol-union-indexer:
-  enabled: true
   replicas: 3
-  resources:
-    jvm:
-      xmx_megabytes: 256
-      max_direct_memory_megabytes: 128
-
-protocol-union-worker:
-  enabled: true
-  replicas: 1
-  resources:
-    jvm:
-      xmx_megabytes: 256
-      max_direct_memory_megabytes: 128

--- a/cicd/deploy/values.yaml
+++ b/cicd/deploy/values.yaml
@@ -21,6 +21,7 @@ protocol-union-api:
     fluentbit.io/parser: logfmt
 
 protocol-union-listener:
+  replicas: 1
   image:
     repository: union-service-listener
   environments:
@@ -39,6 +40,7 @@ protocol-union-listener:
     fluentbit.io/parser: logfmt
 
 protocol-union-meta-loader:
+  replicas: 1
   image:
     repository: union-service-meta-loader
   environments:
@@ -51,13 +53,13 @@ protocol-union-meta-loader:
     node.labels.rarible.service: true
   resources:
     jvm:
-      xmx_megabytes: 1024
-      max_direct_memory_megabytes: 256
+      xmx_megabytes: 512
+      max_direct_memory_megabytes: 128
   podAnnotations:
     fluentbit.io/parser: logfmt
 
 protocol-union-indexer:
-  enabled: false
+  replicas: 1
   image:
     repository: union-service-indexer
   environments:
@@ -70,13 +72,13 @@ protocol-union-indexer:
     node.labels.rarible.service: true
   resources:
     jvm:
-      xmx_megabytes: 1024
-      max_direct_memory_megabytes: 128
+      xmx_megabytes: 256
+      max_direct_memory_megabytes: 64
   podAnnotations:
     fluentbit.io/parser: logfmt
 
 protocol-union-worker:
-  enabled: false
+  replicas: 1
   image:
     repository: union-service-worker
   environments:
@@ -88,7 +90,7 @@ protocol-union-worker:
     node.labels.rarible.service: true
   resources:
     jvm:
-      xmx_megabytes: 1024
-      max_direct_memory_megabytes: 128
+      xmx_megabytes: 256
+      max_direct_memory_megabytes: 64
   podAnnotations:
     fluentbit.io/parser: logfmt


### PR DESCRIPTION
дефолтные значения должны быть в values.yaml. все остальные файлы лишь переопределяют дефолт